### PR TITLE
feat: support labels in parsing

### DIFF
--- a/assembler/src/org/pluverse/cs241/assembler/BUILD
+++ b/assembler/src/org/pluverse/cs241/assembler/BUILD
@@ -8,6 +8,7 @@ kt_jvm_library(
     srcs = [
         "CodeGenVisitor.kt",
         "Main.kt",
+        "PrettyVisitor.kt",
     ],
     deps = [
         "//:antlr_runtime",

--- a/assembler/src/org/pluverse/cs241/assembler/CodeGenVisitor.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/CodeGenVisitor.kt
@@ -42,12 +42,6 @@ class CodeGenVisitor : Arm64AsmBaseVisitor<Void?>() {
 
   // ---------- Visit Program Entry ----------
   override fun visitProgram(ctx: Arm64AsmParser.ProgramContext): Void? {
-    // Visit all statements
-//    for (st in ctx.statement()) {
-//      visit(st)
-//    }
-//    return null
-
     // Note: this is only to make the project compile successfully, not functional.
     for (line in ctx.line()) {
       visit(line)

--- a/assembler/src/org/pluverse/cs241/assembler/CodeGenVisitor.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/CodeGenVisitor.kt
@@ -43,9 +43,17 @@ class CodeGenVisitor : Arm64AsmBaseVisitor<Void?>() {
   // ---------- Visit Program Entry ----------
   override fun visitProgram(ctx: Arm64AsmParser.ProgramContext): Void? {
     // Visit all statements
-    for (st in ctx.statement()) {
-      visit(st)
+//    for (st in ctx.statement()) {
+//      visit(st)
+//    }
+//    return null
+
+    // Note: this is only to make the project compile successfully, not functional.
+    for (line in ctx.line()) {
+      visit(line)
     }
+
+    ctx.lastline()?.let { visit(it) }
     return null
   }
 

--- a/assembler/src/org/pluverse/cs241/assembler/Main.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/Main.kt
@@ -52,7 +52,7 @@ class Main {
       val tree = parser.program()
 
       // Visit the parse tree
-       PrettyVisitor().visit(tree)
+      PrettyVisitor().visit(tree)
 
       val generator = CodeGenVisitor()
       generator.visit(tree)

--- a/assembler/src/org/pluverse/cs241/assembler/Main.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/Main.kt
@@ -52,7 +52,8 @@ class Main {
       val tree = parser.program()
 
       // Visit the parse tree
-      // PrettyVisitor().visit(tree)
+       PrettyVisitor().visit(tree)
+
       val generator = CodeGenVisitor()
       generator.visit(tree)
       val code = generator.machineCode

--- a/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018-2024 University of Waterloo.
+ *
+ * This file is part of Perses.
+ *
+ * Perses is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3, or (at your option) any later version.
+ *
+ * Perses is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Perses; see the file LICENSE.  If not see <http://www.gnu.org/licenses/>.
+ */
 package org.pluverse.cs241.assembler
 
 class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
@@ -16,7 +32,6 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
     }
     return null
   }
-
 
   // program : line* lastline? EOF
   override fun visitProgram(ctx: Arm64AsmParser.ProgramContext): Void? {
@@ -50,7 +65,7 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
    */
   private fun printLabelsAndStatement(
     labelsCtx: Arm64AsmParser.LabelsContext?,
-    stmtCtx: Arm64AsmParser.StatementContext?
+    stmtCtx: Arm64AsmParser.StatementContext?,
   ) {
     if (labelsCtx != null) {
       val defs = labelsCtx.labelDef()
@@ -231,7 +246,7 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
     return when (ctx) {
       is Arm64AsmParser.AddrImmContext -> ctx.imm().text
       is Arm64AsmParser.AddrLabelContext -> ctx.LABEL_ID().text
-      else -> ctx.text  // should not reach here
+      else -> ctx.text // should not reach here
     }
   }
 

--- a/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
@@ -1,0 +1,243 @@
+package org.pluverse.cs241.assembler
+
+class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
+  private var indent = 0
+
+  private fun p(s: String) {
+    println("  ".repeat(indent) + s)
+  }
+
+  private fun withIndent(block: () -> Unit): Void? {
+    indent++
+    try {
+      block()
+    } finally {
+      indent--
+    }
+    return null
+  }
+
+
+  // program : line* lastline? EOF
+  override fun visitProgram(ctx: Arm64AsmParser.ProgramContext): Void? {
+    p("program")
+    return withIndent {
+      // visit lines with NEWLINE
+      for (lineCtx in ctx.line()) {
+        visit(lineCtx)
+      }
+      // deal with lastline if exists
+      ctx.lastline()?.let { visit(it) }
+    }
+  }
+
+  // line : labels? statement? NEWLINE
+  override fun visitLine(ctx: Arm64AsmParser.LineContext): Void? {
+    printLabelsAndStatement(ctx.labels(), ctx.statement())
+    return null
+  }
+
+  // lastline
+  //   : labels statement?
+  //   | statement
+  override fun visitLastline(ctx: Arm64AsmParser.LastlineContext): Void? {
+    printLabelsAndStatement(ctx.labels(), ctx.statement())
+    return null
+  }
+
+  /**
+   * print labels and statement in a line or lastline
+   */
+  private fun printLabelsAndStatement(
+    labelsCtx: Arm64AsmParser.LabelsContext?,
+    stmtCtx: Arm64AsmParser.StatementContext?
+  ) {
+    if (labelsCtx != null) {
+      val defs = labelsCtx.labelDef()
+      val sb = StringBuilder("labels:")
+      for (d in defs) {
+        sb.append(" ").append(d.LABEL_ID().text)
+      }
+      p(sb.toString())
+    }
+
+    if (stmtCtx != null) {
+      visit(stmtCtx)
+    } else if (labelsCtx != null) {
+      // 只有 label 没有指令（纯 label 行）
+      withIndent {
+        p("(no instruction on this line)")
+      }
+    }
+    // both labelsCtx and stmtCtx can be null (empty line)
+  }
+
+  // ---------- arith3 ----------
+
+  override fun visitAdd3(ctx: Arm64AsmParser.Add3Context): Void? {
+    p("add")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitSub3(ctx: Arm64AsmParser.Sub3Context): Void? {
+    p("sub")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitMul3(ctx: Arm64AsmParser.Mul3Context): Void? {
+    p("mul")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitSmulh3(ctx: Arm64AsmParser.Smulh3Context): Void? {
+    p("smulh")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitUmulh3(ctx: Arm64AsmParser.Umulh3Context): Void? {
+    p("umulh")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitSdiv3(ctx: Arm64AsmParser.Sdiv3Context): Void? {
+    p("sdiv")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  override fun visitUdiv3(ctx: Arm64AsmParser.Udiv3Context): Void? {
+    p("udiv")
+    return withIndent {
+      p("rd = " + ctx.reg(0).text)
+      p("rn = " + ctx.reg(1).text)
+      p("rm = " + ctx.reg(2).text)
+    }
+  }
+
+  // ---------- cmp2 ----------
+
+  override fun visitCmpInstr(ctx: Arm64AsmParser.CmpInstrContext): Void? {
+    p("cmp")
+    return withIndent {
+      p("rn = " + ctx.reg(0).text)
+      p("rm = " + ctx.reg(1).text)
+    }
+  }
+
+  // ---------- mem: ldur/stur ----------
+
+  override fun visitLdurMem(ctx: Arm64AsmParser.LdurMemContext): Void? {
+    p("ldur")
+    return withIndent {
+      p("rt  = " + ctx.reg(0).text)
+      p("rn  = " + ctx.reg(1).text)
+      p("imm = " + ctx.imm().text)
+    }
+  }
+
+  override fun visitSturMem(ctx: Arm64AsmParser.SturMemContext): Void? {
+    p("stur")
+    return withIndent {
+      p("rt  = " + ctx.reg(0).text)
+      p("rn  = " + ctx.reg(1).text)
+      p("imm = " + ctx.imm().text)
+    }
+  }
+
+  // ---------- ldr_pc: LDR reg, addr ----------
+
+  override fun visitLdrPc(ctx: Arm64AsmParser.LdrPcContext): Void? {
+    p("ldr (pc-relative)")
+    return withIndent {
+      p("rt   = " + ctx.reg().text)
+      p("addr = " + addrToString(ctx.addr()))
+    }
+  }
+
+  // ---------- branches ----------
+
+  override fun visitBImm(ctx: Arm64AsmParser.BImmContext): Void? {
+    p("b")
+    return withIndent {
+      p("addr = " + addrToString(ctx.addr()))
+    }
+  }
+
+  override fun visitBrReg(ctx: Arm64AsmParser.BrRegContext): Void? {
+    p("br")
+    return withIndent {
+      p("rn = " + ctx.reg().text)
+    }
+  }
+
+  override fun visitBlrReg(ctx: Arm64AsmParser.BlrRegContext): Void? {
+    p("blr")
+    return withIndent {
+      p("rn = " + ctx.reg().text)
+    }
+  }
+
+  override fun visitBCondDot(ctx: Arm64AsmParser.BCondDotContext): Void? {
+    p("b.cond") // b . cond addr
+    return withIndent {
+      p("cond = " + ctx.cond().text)
+      p("addr = " + addrToString(ctx.addr()))
+    }
+  }
+
+  override fun visitBCondPlain(ctx: Arm64AsmParser.BCondPlainContext): Void? {
+    p("b.cond") // b cond addr
+    return withIndent {
+      p("cond = " + ctx.cond().text)
+      p("addr = " + addrToString(ctx.addr()))
+    }
+  }
+
+  // ---------- directive .8byte ----------
+
+  override fun visitDir8Byte(ctx: Arm64AsmParser.Dir8ByteContext): Void? {
+    p(".8byte")
+    return withIndent {
+      p("addr = " + addrToString(ctx.addr()))
+    }
+  }
+
+  // ---------- addr: imm | LABEL_ID ----------
+
+  private fun addrToString(ctx: Arm64AsmParser.AddrContext): String {
+    return when (ctx) {
+      is Arm64AsmParser.AddrImmContext -> ctx.imm().text
+      is Arm64AsmParser.AddrLabelContext -> ctx.LABEL_ID().text
+      else -> ctx.text  // should not reach here
+    }
+  }
+
+  // ---------- default ----------
+
+  override fun defaultResult(): Void? = null
+
+  override fun aggregateResult(aggregate: Void?, nextResult: Void?): Void? = null
+}

--- a/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
+++ b/assembler/src/org/pluverse/cs241/assembler/PrettyVisitor.kt
@@ -19,7 +19,7 @@ package org.pluverse.cs241.assembler
 class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
   private var indent = 0
 
-  private fun p(s: String) {
+  private fun printWithIndent(s: String) {
     println("  ".repeat(indent) + s)
   }
 
@@ -35,7 +35,7 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
 
   // program : line* lastline? EOF
   override fun visitProgram(ctx: Arm64AsmParser.ProgramContext): Void? {
-    p("program")
+    printWithIndent("program")
     return withIndent {
       // visit lines with NEWLINE
       for (lineCtx in ctx.line()) {
@@ -73,15 +73,15 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
       for (d in defs) {
         sb.append(" ").append(d.LABEL_ID().text)
       }
-      p(sb.toString())
+      printWithIndent(sb.toString())
     }
 
     if (stmtCtx != null) {
       visit(stmtCtx)
     } else if (labelsCtx != null) {
-      // 只有 label 没有指令（纯 label 行）
+      // there are labels but no statement
       withIndent {
-        p("(no instruction on this line)")
+        printWithIndent("(no instruction on this line)")
       }
     }
     // both labelsCtx and stmtCtx can be null (empty line)
@@ -90,153 +90,153 @@ class PrettyVisitor : Arm64AsmBaseVisitor<Void?>() {
   // ---------- arith3 ----------
 
   override fun visitAdd3(ctx: Arm64AsmParser.Add3Context): Void? {
-    p("add")
+    printWithIndent("add")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitSub3(ctx: Arm64AsmParser.Sub3Context): Void? {
-    p("sub")
+    printWithIndent("sub")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitMul3(ctx: Arm64AsmParser.Mul3Context): Void? {
-    p("mul")
+    printWithIndent("mul")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitSmulh3(ctx: Arm64AsmParser.Smulh3Context): Void? {
-    p("smulh")
+    printWithIndent("smulh")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitUmulh3(ctx: Arm64AsmParser.Umulh3Context): Void? {
-    p("umulh")
+    printWithIndent("umulh")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitSdiv3(ctx: Arm64AsmParser.Sdiv3Context): Void? {
-    p("sdiv")
+    printWithIndent("sdiv")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   override fun visitUdiv3(ctx: Arm64AsmParser.Udiv3Context): Void? {
-    p("udiv")
+    printWithIndent("udiv")
     return withIndent {
-      p("rd = " + ctx.reg(0).text)
-      p("rn = " + ctx.reg(1).text)
-      p("rm = " + ctx.reg(2).text)
+      printWithIndent("rd = " + ctx.reg(0).text)
+      printWithIndent("rn = " + ctx.reg(1).text)
+      printWithIndent("rm = " + ctx.reg(2).text)
     }
   }
 
   // ---------- cmp2 ----------
 
   override fun visitCmpInstr(ctx: Arm64AsmParser.CmpInstrContext): Void? {
-    p("cmp")
+    printWithIndent("cmp")
     return withIndent {
-      p("rn = " + ctx.reg(0).text)
-      p("rm = " + ctx.reg(1).text)
+      printWithIndent("rn = " + ctx.reg(0).text)
+      printWithIndent("rm = " + ctx.reg(1).text)
     }
   }
 
   // ---------- mem: ldur/stur ----------
 
   override fun visitLdurMem(ctx: Arm64AsmParser.LdurMemContext): Void? {
-    p("ldur")
+    printWithIndent("ldur")
     return withIndent {
-      p("rt  = " + ctx.reg(0).text)
-      p("rn  = " + ctx.reg(1).text)
-      p("imm = " + ctx.imm().text)
+      printWithIndent("rt  = " + ctx.reg(0).text)
+      printWithIndent("rn  = " + ctx.reg(1).text)
+      printWithIndent("imm = " + ctx.imm().text)
     }
   }
 
   override fun visitSturMem(ctx: Arm64AsmParser.SturMemContext): Void? {
-    p("stur")
+    printWithIndent("stur")
     return withIndent {
-      p("rt  = " + ctx.reg(0).text)
-      p("rn  = " + ctx.reg(1).text)
-      p("imm = " + ctx.imm().text)
+      printWithIndent("rt  = " + ctx.reg(0).text)
+      printWithIndent("rn  = " + ctx.reg(1).text)
+      printWithIndent("imm = " + ctx.imm().text)
     }
   }
 
   // ---------- ldr_pc: LDR reg, addr ----------
 
   override fun visitLdrPc(ctx: Arm64AsmParser.LdrPcContext): Void? {
-    p("ldr (pc-relative)")
+    printWithIndent("ldr (pc-relative)")
     return withIndent {
-      p("rt   = " + ctx.reg().text)
-      p("addr = " + addrToString(ctx.addr()))
+      printWithIndent("rt   = " + ctx.reg().text)
+      printWithIndent("addr = " + addrToString(ctx.addr()))
     }
   }
 
   // ---------- branches ----------
 
   override fun visitBImm(ctx: Arm64AsmParser.BImmContext): Void? {
-    p("b")
+    printWithIndent("b")
     return withIndent {
-      p("addr = " + addrToString(ctx.addr()))
+      printWithIndent("addr = " + addrToString(ctx.addr()))
     }
   }
 
   override fun visitBrReg(ctx: Arm64AsmParser.BrRegContext): Void? {
-    p("br")
+    printWithIndent("br")
     return withIndent {
-      p("rn = " + ctx.reg().text)
+      printWithIndent("rn = " + ctx.reg().text)
     }
   }
 
   override fun visitBlrReg(ctx: Arm64AsmParser.BlrRegContext): Void? {
-    p("blr")
+    printWithIndent("blr")
     return withIndent {
-      p("rn = " + ctx.reg().text)
+      printWithIndent("rn = " + ctx.reg().text)
     }
   }
 
   override fun visitBCondDot(ctx: Arm64AsmParser.BCondDotContext): Void? {
-    p("b.cond") // b . cond addr
+    printWithIndent("b.cond") // b . cond addr
     return withIndent {
-      p("cond = " + ctx.cond().text)
-      p("addr = " + addrToString(ctx.addr()))
+      printWithIndent("cond = " + ctx.cond().text)
+      printWithIndent("addr = " + addrToString(ctx.addr()))
     }
   }
 
   override fun visitBCondPlain(ctx: Arm64AsmParser.BCondPlainContext): Void? {
-    p("b.cond") // b cond addr
+    printWithIndent("b.cond") // b cond addr
     return withIndent {
-      p("cond = " + ctx.cond().text)
-      p("addr = " + addrToString(ctx.addr()))
+      printWithIndent("cond = " + ctx.cond().text)
+      printWithIndent("addr = " + addrToString(ctx.addr()))
     }
   }
 
   // ---------- directive .8byte ----------
 
   override fun visitDir8Byte(ctx: Arm64AsmParser.Dir8ByteContext): Void? {
-    p(".8byte")
+    printWithIndent(".8byte")
     return withIndent {
-      p("addr = " + addrToString(ctx.addr()))
+      printWithIndent("addr = " + addrToString(ctx.addr()))
     }
   }
 

--- a/assembler/src/org/pluverse/cs241/assembler/grammar/Arm64Asm.g4
+++ b/assembler/src/org/pluverse/cs241/assembler/grammar/Arm64Asm.g4
@@ -3,9 +3,6 @@ grammar Arm64Asm;
 @header { package org.pluverse.cs241.assembler; }
 
 // ---------- Parser ----------
-//program
-//  : line* EOF
-//  ;
 
 program
   : line* lastline? EOF
@@ -142,7 +139,6 @@ SP   : 'sp';
 XREG : 'x' DIGIT+;
 
 // label identifiers
-//LABEL_ID : [a-zA-Z] [a-zA-Z0-9]* ; // this strictly follows course specs, which does not allow '_'
 LABEL_ID : [a-zA-Z_] [a-zA-Z0-9_]*;
 
 // immediates

--- a/assembler/src/org/pluverse/cs241/assembler/grammar/Arm64Asm.g4
+++ b/assembler/src/org/pluverse/cs241/assembler/grammar/Arm64Asm.g4
@@ -142,8 +142,8 @@ SP   : 'sp';
 XREG : 'x' DIGIT+;
 
 // label identifiers
-LABEL_ID : [a-zA-Z] [a-zA-Z0-9]* ; // this strictly follows course specs, which does not allow '_'
-//LABEL_ID : [a-zA-Z_] [a-zA-Z0-9_]*; // replace with this line to allow '_' in labels
+//LABEL_ID : [a-zA-Z] [a-zA-Z0-9]* ; // this strictly follows course specs, which does not allow '_'
+LABEL_ID : [a-zA-Z_] [a-zA-Z0-9_]*;
 
 // immediates
 DEC_INT : '-'? DIGIT+;

--- a/assembler/test/org/pluverse/cs241/assembler/BUILD
+++ b/assembler/test/org/pluverse/cs241/assembler/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+load("//test:test.bzl", "golden_test")
 
 kt_jvm_test(
     name = "CodeGenVisitorTest",
@@ -10,4 +11,29 @@ kt_jvm_test(
         "//:antlr_runtime",
         "//:truth",
     ],
+)
+
+ASSEMBLER_BINARY = "//assembler/src/org/pluverse/cs241/assembler:assembler"
+
+genrule(
+    name = "generate_pretty_visitor_output",
+    srcs = [
+        "testdata/all.asm",
+    ],
+    outs = [
+        "pretty_visitor_output.txt",
+    ],
+    cmd = "$(location %s) " % ASSEMBLER_BINARY +
+          " $(location testdata/all.asm) " +
+          " /dev/null " +
+          " 2>&1 | sed '$$d' > $@",
+    tools = [
+        ASSEMBLER_BINARY,
+    ],
+)
+
+golden_test(
+    name = "golden_test_pretty_visitor",
+    golden_file = "pretty_visitor_output.golden.txt",
+    test_file = "pretty_visitor_output.txt",
 )

--- a/assembler/test/org/pluverse/cs241/assembler/pretty_visitor_output.golden.txt
+++ b/assembler/test/org/pluverse/cs241/assembler/pretty_visitor_output.golden.txt
@@ -1,0 +1,200 @@
+program
+  labels: Start
+    (no instruction on this line)
+  labels: EntryPoint
+    (no instruction on this line)
+  labels: Main MainLoop
+    (no instruction on this line)
+  add
+    rd = x0
+    rn = x1
+    rm = x2
+  sub
+    rd = x3
+    rn = x4
+    rm = x5
+  mul
+    rd = x6
+    rn = x7
+    rm = x8
+  smulh
+    rd = x9
+    rn = x10
+    rm = x11
+  umulh
+    rd = x12
+    rn = x13
+    rm = x14
+  sdiv
+    rd = x15
+    rn = x16
+    rm = x17
+  udiv
+    rd = x18
+    rn = x19
+    rm = x20
+  labels: CompareBlock
+    (no instruction on this line)
+  cmp
+    rn = x21
+    rm = x22
+  labels: MemBlock1
+    (no instruction on this line)
+  ldur
+    rt  = x0
+    rn  = x1
+    imm = -8
+  stur
+    rt  = x2
+    rn  = x3
+    imm = 0
+  ldur
+    rt  = x4
+    rn  = x5
+    imm = 16
+  stur
+    rt  = x6
+    rn  = x7
+    imm = 0x20
+  labels: PCRelBlock
+    (no instruction on this line)
+  ldr (pc-relative)
+    rt   = x8
+    addr = 32
+  ldr (pc-relative)
+    rt   = x9
+    addr = JumpTable
+  b
+    addr = 16
+  b
+    addr = Loop1
+  br
+    rn = x30
+  blr
+    rn = x29
+  labels: Loop1
+    (no instruction on this line)
+  cmp
+    rn = x0
+    rm = x1
+  b.cond
+    cond = eq
+    addr = EndBlock
+  b.cond
+    cond = ne
+    addr = Loop1
+  labels: CondTest
+    (no instruction on this line)
+  cmp
+    rn = x2
+    rm = x3
+  b.cond
+    cond = hs
+    addr = GreaterOrEqual
+  b.cond
+    cond = lo
+    addr = LessThan
+  b.cond
+    cond = hi
+    addr = StrictGreater
+  b.cond
+    cond = ls
+    addr = LessOrEqual
+  b.cond
+    cond = ge
+    addr = GreaterOrEqual
+  b.cond
+    cond = lt
+    addr = LessThan
+  b.cond
+    cond = gt
+    addr = StrictGreater
+  b.cond
+    cond = le
+    addr = LessOrEqual
+  labels: GreaterOrEqual
+    (no instruction on this line)
+  add
+    rd = x0
+    rn = x0
+    rm = x1
+  b
+    addr = Done
+  labels: LessThan
+    (no instruction on this line)
+  sub
+    rd = x0
+    rn = x0
+    rm = x1
+  b
+    addr = Done
+  labels: StrictGreater
+    (no instruction on this line)
+  mul
+    rd = x0
+    rn = x0
+    rm = x1
+  b
+    addr = Done
+  labels: DataSection1
+    (no instruction on this line)
+  .8byte
+    addr = 0
+  .8byte
+    addr = -1
+  .8byte
+    addr = 0x1234ABCD
+  .8byte
+    addr = Start
+  .8byte
+    addr = JumpTable
+  labels: JumpTable
+    (no instruction on this line)
+  .8byte
+    addr = Case0
+  .8byte
+    addr = Case1
+  .8byte
+    addr = Case2
+  labels: Case0
+    (no instruction on this line)
+  add
+    rd = x1
+    rn = x1
+    rm = x1
+  b
+    addr = Done
+  labels: Case1
+    (no instruction on this line)
+  sub
+    rd = x1
+    rn = x1
+    rm = x2
+  b
+    addr = Done
+  labels: Case2
+    (no instruction on this line)
+  mul
+    rd = x1
+    rn = x1
+    rm = x2
+  b
+    addr = Done
+  labels: Loop2
+    (no instruction on this line)
+  labels: LOOP3
+    (no instruction on this line)
+  labels: Data2Section42
+    (no instruction on this line)
+  cmp
+    rn = xzr
+    rm = x0
+  b.cond
+    cond = ne
+    addr = MainLoop
+  labels: EndBlock
+    (no instruction on this line)
+  labels: Done
+    (no instruction on this line)
+  br
+    rn = x30

--- a/assembler/test/org/pluverse/cs241/assembler/testdata/all.asm
+++ b/assembler/test/org/pluverse/cs241/assembler/testdata/all.asm
@@ -1,0 +1,99 @@
+Start:
+EntryPoint:
+
+Main: MainLoop:
+  add x0, x1, x2         // add (Add3)
+
+// arithmetic
+  sub   x3, x4, x5       // sub (Sub3)
+  mul   x6, x7, x8       // mul (Mul3)
+  smulh x9, x10, x11     // smulh (Smulh3)
+  umulh x12, x13, x14    // umulh (Umulh3)
+  sdiv  x15, x16, x17    // sdiv (Sdiv3)
+  udiv  x18, x19, x20    // udiv (Udiv3)
+
+// cmp
+CompareBlock:
+  cmp x21, x22           // cmp (CmpInstr)
+
+MemBlock1:
+  ldur x0,  [x1, -8]
+  stur x2,  [x3, 0]
+  ldur x4,  [x5, 16]
+  stur x6,  [x7, 0x20]
+
+PCRelBlock:
+  ldr x8,  32            // LdrPc + AddrImm
+  ldr x9,  JumpTable     // LdrPc + AddrLabel
+  b 16                   // BImm + AddrImm
+  b Loop1                // BImm + AddrLabel
+
+  br  x30                // BrReg
+  blr x29                // BlrReg
+
+Loop1:
+  cmp x0, x1
+  b.eq EndBlock          // BCondPlain (b cond addr)
+  b . ne Loop1           // BCondDot   (b . cond addr)
+
+CondTest:
+  cmp x2, x3
+  b.hs GreaterOrEqual    // hs
+  b.lo LessThan         // lo
+  b.hi StrictGreater    // hi
+  b.ls LessOrEqual      // ls
+  b.ge GreaterOrEqual   // ge
+  b.lt LessThan         // lt
+  b.gt StrictGreater    // gt
+  b.le LessOrEqual      // le
+
+GreaterOrEqual:
+  add x0, x0, x1
+  b Done
+
+LessThan:
+  sub x0, x0, x1
+  b Done
+
+StrictGreater:
+  mul x0, x0, x1
+  b Done
+
+// .8byte
+DataSection1:
+  .8byte 0
+  .8byte -1
+  .8byte 0x1234ABCD
+  .8byte Start
+  .8byte JumpTable
+
+JumpTable:
+  .8byte Case0
+  .8byte Case1
+  .8byte Case2
+
+Case0:
+  add x1, x1, x1
+  b Done
+
+Case1:
+  sub x1, x1, x2
+  b Done
+
+Case2:
+  mul x1, x1, x2
+  b Done
+
+Loop2:
+LOOP3:
+Data2Section42:
+  cmp xzr, x0
+  b.ne MainLoop
+
+
+// comment only line
+
+
+EndBlock:
+Done:
+  br x30


### PR DESCRIPTION
The parser should be able to handle labels now. I take the PrettyVisitor back for now for reference, and slightly modified CodeGenVisitor to make it compilable.

Note: the current grammar design does not allow the label name to be identical to instruction names, e.g., `.add` is not allowed. This is for convenience and to follow the real-world convention, though it differs slightly from the course documentation.
